### PR TITLE
Add roseus_resume to dependencies

### DIFF
--- a/pr2eus/package.xml
+++ b/pr2eus/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>roseus</build_depend>
+  <build_depend>roseus_resume</build_depend>
   <build_depend>euscollada</build_depend>
   <build_depend>pr2_msgs</build_depend>
   <build_depend>pr2_controllers_msgs</build_depend>
@@ -24,6 +25,7 @@
   <build_depend>rosgraph_msgs</build_depend>
 
   <run_depend>roseus</run_depend>
+  <run_depend>roseus_resume</run_depend>
   <run_depend>euscollada</run_depend>
   <run_depend>pr2_msgs</run_depend>
   <run_depend>pr2_controllers_msgs</run_depend>


### PR DESCRIPTION
Add roseus_resume to pr2eus dependencies.
Note that we also need https://github.com/Affonso-Gui/roseus_resume/commit/315e18f1fed8f6f039898082ac6a424e845a88a6 to avoid cyclic dependencies.

ref. https://github.com/jsk-ros-pkg/jsk_robot/pull/1654